### PR TITLE
WIP: [ariac-server] Generalize build-image script to accept multiple Ubuntu distros

### DIFF
--- a/ariac-server/ariac-server/Dockerfile
+++ b/ariac-server/ariac-server/Dockerfile
@@ -10,82 +10,27 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Need these before sources can be set up
 RUN apt-get update \
- && apt-get install -y \
-    gnupg2 \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-# setup keys and sources for official Gazebo and ROS debian packages
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743 \
+ && apt-get install -y gnupg2 \
+ # setup keys and sources for official Gazebo and ROS debian packages
+ && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743 \
  && echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $UBUNTU_DISTRO main" > /etc/apt/sources.list.d/gazebo-latest.list \
  && apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654 \
- && echo "deb http://packages.ros.org/ros/ubuntu $UBUNTU_DISTRO main" > /etc/apt/sources.list.d/ros-latest.list
+ && echo "deb http://packages.ros.org/ros/ubuntu $UBUNTU_DISTRO main" > /etc/apt/sources.list.d/ros-latest.list \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN echo "DEBUG:" && cat /etc/apt/sources.list.d/ros-latest.list
-
-# install ROS and Gazebo packages
+# install OS tools
 RUN apt-get update && apt-get install -q -y \
     bash-completion \
-    gazebo9 \
-    libgazebo9-dev \
     locales \
     psmisc \
     python3-rosdep \
     python3-vcstool \
-    ros-${ROSDISTRO}-robot-state-publisher \
-    ros-${ROSDISTRO}-camera-info-manager \
-    ros-${ROSDISTRO}-ros-control \
-    ros-${ROSDISTRO}-ros-controllers \
-    ros-${ROSDISTRO}-ros-core \
-    ros-${ROSDISTRO}-image-transport \
-    ros-${ROSDISTRO}-cv-bridge \
-    ros-${ROSDISTRO}-joint-limits-interface \
-    ros-${ROSDISTRO}-polled-camera \
-    ros-${ROSDISTRO}-diagnostic-updater \
-    ros-${ROSDISTRO}-transmission-interface \
-    ros-${ROSDISTRO}-ros-base \
-    ros-${ROSDISTRO}-moveit \
     wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # bootstrap rosdep
 RUN rosdep init
-
-# Need to install a specific version of gazebo_ros_pkgs
-# 1. Remove official packages
-RUN export GZ_VERSION=9 && \
-    dpkg -r --force-depends ros-${ROSDISTRO}-gazebo${GZ_VERSION}-ros-pkgs \
-                            ros-${ROSDISTRO}-gazebo${GZ_VERSION}-ros \
-                            ros-${ROSDISTRO}-gazebo${GZ_VERSION}-plugins \
-                            ros-${ROSDISTRO}-gazebo${GZ_VERSION}-msgs \
-                            ros-${ROSDISTRO}-gazebo${GZ_VERSION}-ros-control
-
-
-
-
-# RUN /bin/bash -c "cd /tmp/ariac_ws/src && \
-#                 git clone https://github.com/usnistgov/ARIAC.git"
-
-
-
-
-
-# 3. Build the version from source
-RUN mkdir -p /tmp/ros_ws/src
-RUN /bin/bash -c "source /opt/ros/${ROSDISTRO}/setup.bash && \
-                  cd /tmp/ros_ws/src && \
-                  catkin_init_workspace"
-# RUN git clone \
-#       https://github.com/osrf/ariac-gazebo_ros_pkgs.git /tmp/ros_ws/src/gazebo_ros_pkgs \
-#       -b ariac-network-${ROSDISTRO}
-
-# RUN /bin/bash -c "source /opt/ros/${ROSDISTRO}/setup.bash && \
-#                   cd /tmp/ros_ws/ && \
-#                   catkin_make -DCMAKE_INSTALL_PREFIX=/opt/ros/${ROSDISTRO} -j2 install "
-
-
-
 
 # Expose port used to communicate with gzserver
 EXPOSE 11345
@@ -108,27 +53,28 @@ RUN echo "export QT_X11_NO_MITSHM=1" >> /home/$USERNAME/.bashrc
 USER $USERNAME
 WORKDIR /home/$USERNAME
 
+ENV CWS_ARIAC=/home/ariac/ariac_ws/
 # Get gazebo models early since it is big
-RUN wget -P /tmp/ https://github.com/osrf/gazebo_models/archive/master.zip \
- && mkdir -p $HOME/.gazebo/models \
- && tar -xvf /tmp/default.tar.gz -C $HOME/.gazebo/models --strip 1 \
- && rm /tmp/default.tar.gz
+##RUN wget -P /tmp/ https://github.com/osrf/gazebo_models/archive/master.zip \
+## && mkdir -p $HOME/.gazebo/models \
+## && tar -xvf /tmp/default.tar.gz -C $HOME/.gazebo/models --strip 1 \
+## && rm /tmp/default.tar.gz
 
 
  #Download and compile ARIAC 2020
- RUN mkdir -p /home/ariac/ariac_ws/src
+ RUN mkdir -p $CWS_ARIAC/src
  RUN mkdir -p /tmp/gazebo_ws
 
  RUN git clone \
       https://github.com/osrf/ariac-gazebo_ros_pkgs.git /tmp/gazebo_ws \
       -b ariac-network-${ROSDISTRO}
- RUN git clone https://github.com/usnistgov/ARIAC.git  /home/ariac/ariac_ws/src
- RUN /bin/bash -c "cp -rf /tmp/gazebo_ws /home/ariac/ariac_ws/src"
+ RUN git clone https://github.com/usnistgov/ARIAC.git  $CWS_ARIAC/src
+ RUN /bin/bash -c "cp -rf /tmp/gazebo_ws $CWS_ARIAC/src"
 
  RUN /bin/bash -c "source /opt/ros/${ROSDISTRO}/setup.bash && \
-                   cd /home/ariac/ariac_ws && \
+                   cd $CWS_ARIAC && \
+                   rosdep install -y --from-paths src --ignore-src && \
                    catkin_make"
-
 
 # setup entrypoint
 COPY ./ariac_entrypoint.sh /

--- a/ariac-server/ariac-server/Dockerfile
+++ b/ariac-server/ariac-server/Dockerfile
@@ -1,4 +1,9 @@
-FROM ubuntu:bionic
+ARG UBUNTU_DISTRO
+FROM ubuntu:${UBUNTU_DISTRO}
+
+# Re-defining UBUNTU_DISTRO, as 'ARG's need to be defined after FROM, except the one meant to be passed to FROM https://stackoverflow.com/a/63086565/577001
+ARG UBUNTU_DISTRO=focal
+ARG ROSDISTRO="noetic"
 
 # Hint to dpkg and apt that packages should be installed without asking for human intervention
 ENV DEBIAN_FRONTEND noninteractive
@@ -12,9 +17,9 @@ RUN apt-get update \
 
 # setup keys and sources for official Gazebo and ROS debian packages
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743 \
- && echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main" > /etc/apt/sources.list.d/gazebo-latest.list \
+ && echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $UBUNTU_DISTRO main" > /etc/apt/sources.list.d/gazebo-latest.list \
  && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654 \
- && echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list
+ && echo "deb http://packages.ros.org/ros/ubuntu ${ROSDISTRO} main" > /etc/apt/sources.list.d/ros-latest.list
 
 # install ROS and Gazebo packages
 RUN apt-get update && apt-get install -q -y \
@@ -26,19 +31,19 @@ RUN apt-get update && apt-get install -q -y \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
-    ros-melodic-robot-state-publisher \
-    ros-melodic-camera-info-manager \
-    ros-melodic-ros-control \
-    ros-melodic-ros-controllers \
-    ros-melodic-ros-core \
-    ros-melodic-image-transport \
-    ros-melodic-cv-bridge \
-    ros-melodic-joint-limits-interface \
-    ros-melodic-polled-camera \
-    ros-melodic-diagnostic-updater \
-    ros-melodic-transmission-interface \
-    ros-melodic-ros-base \
-    ros-melodic-moveit \
+    ros-${ROSDISTRO}-robot-state-publisher \
+    ros-${ROSDISTRO}-camera-info-manager \
+    ros-${ROSDISTRO}-ros-control \
+    ros-${ROSDISTRO}-ros-controllers \
+    ros-${ROSDISTRO}-ros-core \
+    ros-${ROSDISTRO}-image-transport \
+    ros-${ROSDISTRO}-cv-bridge \
+    ros-${ROSDISTRO}-joint-limits-interface \
+    ros-${ROSDISTRO}-polled-camera \
+    ros-${ROSDISTRO}-diagnostic-updater \
+    ros-${ROSDISTRO}-transmission-interface \
+    ros-${ROSDISTRO}-ros-base \
+    ros-${ROSDISTRO}-moveit \
     wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -49,11 +54,11 @@ RUN rosdep init
 # Need to install a specific version of gazebo_ros_pkgs
 # 1. Remove official packages
 RUN export GZ_VERSION=9 && \
-    dpkg -r --force-depends ros-melodic-gazebo${GZ_VERSION}-ros-pkgs \
-                            ros-melodic-gazebo${GZ_VERSION}-ros \
-                            ros-melodic-gazebo${GZ_VERSION}-plugins \
-                            ros-melodic-gazebo${GZ_VERSION}-msgs \
-                            ros-melodic-gazebo${GZ_VERSION}-ros-control
+    dpkg -r --force-depends ros-${ROSDISTRO}-gazebo${GZ_VERSION}-ros-pkgs \
+                            ros-${ROSDISTRO}-gazebo${GZ_VERSION}-ros \
+                            ros-${ROSDISTRO}-gazebo${GZ_VERSION}-plugins \
+                            ros-${ROSDISTRO}-gazebo${GZ_VERSION}-msgs \
+                            ros-${ROSDISTRO}-gazebo${GZ_VERSION}-ros-control
 
 
 
@@ -67,16 +72,16 @@ RUN export GZ_VERSION=9 && \
 
 # 3. Build the version from source
 RUN mkdir -p /tmp/ros_ws/src
-RUN /bin/bash -c "source /opt/ros/melodic/setup.bash && \
+RUN /bin/bash -c "source /opt/ros/${ROSDISTRO}/setup.bash && \
                   cd /tmp/ros_ws/src && \
                   catkin_init_workspace"
 # RUN git clone \
 #       https://github.com/osrf/ariac-gazebo_ros_pkgs.git /tmp/ros_ws/src/gazebo_ros_pkgs \
-#       -b ariac-network-melodic
+#       -b ariac-network-${ROSDISTRO}
 
-# RUN /bin/bash -c "source /opt/ros/melodic/setup.bash && \
+# RUN /bin/bash -c "source /opt/ros/${ROSDISTRO}/setup.bash && \
 #                   cd /tmp/ros_ws/ && \
-#                   catkin_make -DCMAKE_INSTALL_PREFIX=/opt/ros/melodic -j2 install "
+#                   catkin_make -DCMAKE_INSTALL_PREFIX=/opt/ros/${ROSDISTRO} -j2 install "
 
 
 
@@ -115,11 +120,11 @@ RUN wget -P /tmp/ https://github.com/osrf/gazebo_models/archive/master.zip \
 
  RUN git clone \
       https://github.com/osrf/ariac-gazebo_ros_pkgs.git /tmp/gazebo_ws \
-      -b ariac-network-melodic
+      -b ariac-network-${ROSDISTRO}
  RUN git clone https://github.com/usnistgov/ARIAC.git  /home/ariac/ariac_ws/src
  RUN /bin/bash -c "cp -rf /tmp/gazebo_ws /home/ariac/ariac_ws/src"
 
- RUN /bin/bash -c "source /opt/ros/melodic/setup.bash && \
+ RUN /bin/bash -c "source /opt/ros/${ROSDISTRO}/setup.bash && \
                    cd /home/ariac/ariac_ws && \
                    catkin_make"
 

--- a/ariac-server/ariac-server/Dockerfile
+++ b/ariac-server/ariac-server/Dockerfile
@@ -1,5 +1,5 @@
-ARG ROSDISTRO="noetic"
-FROM ros:${ROSDISTRO}-ros-base
+ARG BASE_DIMG
+FROM $BASE_DIMG
 
 SHELL ["/bin/bash", "-c"]
 
@@ -60,17 +60,17 @@ ENV CWS_ARIAC=/home/$USERNAME/ariac_ws/
 ## && tar -xvf /tmp/default.tar.gz -C $HOME/.gazebo/models --strip 1 \
 ## && rm /tmp/default.tar.gz
 
- #Download and compile ARIAC 2020
- RUN mkdir -p $CWS_ARIAC/src && mkdir -p /tmp/gazebo_ws \
-     && git clone https://github.com/osrf/ariac-gazebo_ros_pkgs.git /tmp/gazebo_ws \
-        -b ariac-network-melodic  # This won't work for Noetic as Noetic version doesn't seem to be made yet.
- RUN git clone --depth=1 https://github.com/usnistgov/ARIAC.git  $CWS_ARIAC/src \
-     && cp -rf /tmp/gazebo_ws $CWS_ARIAC/src \
-     && echo "DEBUG: ${ROSDISTRO}" \
-     && source /opt/ros/${ROSDISTRO}/setup.bash \
-     && cd $CWS_ARIAC \
-     && rosdep init && rosdep install -y --from-paths src --ignore-src \
-     && catkin_make
+#Download and compile ARIAC 2020
+RUN mkdir -p $CWS_ARIAC/src && wget https://raw.githubusercontent.com/130s/ARIAC/feature-cleanup-dependency/dev.repos -O $CWS_ARIAC/src/dev.repos \
+    && cd $CWS_ARIAC && vcs import --debug --skip-existing $CWS_ARIAC < $CWS_ARIAC/src/dev.repos
+# Workaround for apt cannot be run https://stackoverflow.com/a/57930100/577001
+USER root
+RUN echo "DEBUG: ${ROSDISTRO}" \
+    && source /opt/ros/${ROSDISTRO}/setup.bash \
+    && cd $CWS_ARIAC \
+    && sudo apt update && rosdep update && rosdep install -y --from-paths src --ignore-src \
+    && catkin_make
+USER $USERNAME
 
 # setup entrypoint
 COPY ./ariac_entrypoint.sh /

--- a/ariac-server/ariac-server/Dockerfile
+++ b/ariac-server/ariac-server/Dockerfile
@@ -67,7 +67,7 @@ ENV CWS_ARIAC=/home/ariac/ariac_ws/
 
  RUN git clone \
       https://github.com/osrf/ariac-gazebo_ros_pkgs.git /tmp/gazebo_ws \
-      -b ariac-network-${ROSDISTRO}
+      -b ariac-network-melodic  # This won't work for Noetic as Noetic version doesn't seem to be made yet.
  RUN git clone https://github.com/usnistgov/ARIAC.git  $CWS_ARIAC/src
  RUN /bin/bash -c "cp -rf /tmp/gazebo_ws $CWS_ARIAC/src"
 

--- a/ariac-server/ariac-server/Dockerfile
+++ b/ariac-server/ariac-server/Dockerfile
@@ -18,8 +18,10 @@ RUN apt-get update \
 # setup keys and sources for official Gazebo and ROS debian packages
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743 \
  && echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $UBUNTU_DISTRO main" > /etc/apt/sources.list.d/gazebo-latest.list \
- && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654 \
- && echo "deb http://packages.ros.org/ros/ubuntu ${ROSDISTRO} main" > /etc/apt/sources.list.d/ros-latest.list
+ && apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654 \
+ && echo "deb http://packages.ros.org/ros/ubuntu $UBUNTU_DISTRO main" > /etc/apt/sources.list.d/ros-latest.list
+
+RUN echo "DEBUG:" && cat /etc/apt/sources.list.d/ros-latest.list
 
 # install ROS and Gazebo packages
 RUN apt-get update && apt-get install -q -y \
@@ -28,9 +30,8 @@ RUN apt-get update && apt-get install -q -y \
     libgazebo9-dev \
     locales \
     psmisc \
-    python-rosdep \
-    python-rosinstall \
-    python-vcstools \
+    python3-rosdep \
+    python3-vcstool \
     ros-${ROSDISTRO}-robot-state-publisher \
     ros-${ROSDISTRO}-camera-info-manager \
     ros-${ROSDISTRO}-ros-control \

--- a/ariac-server/ariac-server/Dockerfile
+++ b/ariac-server/ariac-server/Dockerfile
@@ -1,9 +1,13 @@
-ARG UBUNTU_DISTRO
-FROM ubuntu:${UBUNTU_DISTRO}
-
-# Re-defining UBUNTU_DISTRO, as 'ARG's need to be defined after FROM, except the one meant to be passed to FROM https://stackoverflow.com/a/63086565/577001
-ARG UBUNTU_DISTRO=focal
 ARG ROSDISTRO="noetic"
+FROM ros:${ROSDISTRO}-ros-base
+
+SHELL ["/bin/bash", "-c"]
+
+# Re-defining ROSDISTRO, as 'ARG's need to be defined after FROM, except the one meant to be passed to FROM https://stackoverflow.com/a/63086565/577001
+ARG ROSDISTRO="noetic"
+ARG UBUNTU_DISTRO=focal
+
+RUN echo "DEBUG: ${ROSDISTRO}"
 
 # Hint to dpkg and apt that packages should be installed without asking for human intervention
 ENV DEBIAN_FRONTEND noninteractive
@@ -11,16 +15,15 @@ ENV DEBIAN_FRONTEND noninteractive
 # Need these before sources can be set up
 RUN apt-get update \
  && apt-get install -y gnupg2 \
- # setup keys and sources for official Gazebo and ROS debian packages
+ # setup keys and sources for official Gazebo debian packages
  && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743 \
  && echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $UBUNTU_DISTRO main" > /etc/apt/sources.list.d/gazebo-latest.list \
- && apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654 \
- && echo "deb http://packages.ros.org/ros/ubuntu $UBUNTU_DISTRO main" > /etc/apt/sources.list.d/ros-latest.list \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install OS tools
 RUN apt-get update && apt-get install -q -y \
     bash-completion \
+    git \
     locales \
     psmisc \
     python3-rosdep \
@@ -28,9 +31,6 @@ RUN apt-get update && apt-get install -q -y \
     wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-# bootstrap rosdep
-RUN rosdep init
 
 # Expose port used to communicate with gzserver
 EXPOSE 11345
@@ -47,34 +47,30 @@ ENV LANG en_US.UTF-8
 # Create a new user called ariac. Note: we don't add them to the sudo group
 ENV USERNAME ariac
 ARG USERID=1000
-RUN adduser -u $USERID --gecos "Development User" --disabled-password $USERNAME
-RUN echo "export QT_X11_NO_MITSHM=1" >> /home/$USERNAME/.bashrc
+RUN adduser -u $USERID --gecos "Development User" --disabled-password $USERNAME \
+    && echo "export QT_X11_NO_MITSHM=1" >> /home/$USERNAME/.bashrc
 
 USER $USERNAME
 WORKDIR /home/$USERNAME
 
-ENV CWS_ARIAC=/home/ariac/ariac_ws/
+ENV CWS_ARIAC=/home/$USERNAME/ariac_ws/
 # Get gazebo models early since it is big
 ##RUN wget -P /tmp/ https://github.com/osrf/gazebo_models/archive/master.zip \
 ## && mkdir -p $HOME/.gazebo/models \
 ## && tar -xvf /tmp/default.tar.gz -C $HOME/.gazebo/models --strip 1 \
 ## && rm /tmp/default.tar.gz
 
-
  #Download and compile ARIAC 2020
- RUN mkdir -p $CWS_ARIAC/src
- RUN mkdir -p /tmp/gazebo_ws
-
- RUN git clone \
-      https://github.com/osrf/ariac-gazebo_ros_pkgs.git /tmp/gazebo_ws \
-      -b ariac-network-melodic  # This won't work for Noetic as Noetic version doesn't seem to be made yet.
- RUN git clone https://github.com/usnistgov/ARIAC.git  $CWS_ARIAC/src
- RUN /bin/bash -c "cp -rf /tmp/gazebo_ws $CWS_ARIAC/src"
-
- RUN /bin/bash -c "source /opt/ros/${ROSDISTRO}/setup.bash && \
-                   cd $CWS_ARIAC && \
-                   rosdep install -y --from-paths src --ignore-src && \
-                   catkin_make"
+ RUN mkdir -p $CWS_ARIAC/src && mkdir -p /tmp/gazebo_ws \
+     && git clone https://github.com/osrf/ariac-gazebo_ros_pkgs.git /tmp/gazebo_ws \
+        -b ariac-network-melodic  # This won't work for Noetic as Noetic version doesn't seem to be made yet.
+ RUN git clone --depth=1 https://github.com/usnistgov/ARIAC.git  $CWS_ARIAC/src \
+     && cp -rf /tmp/gazebo_ws $CWS_ARIAC/src \
+     && echo "DEBUG: ${ROSDISTRO}" \
+     && source /opt/ros/${ROSDISTRO}/setup.bash \
+     && cd $CWS_ARIAC \
+     && rosdep init && rosdep install -y --from-paths src --ignore-src \
+     && catkin_make
 
 # setup entrypoint
 COPY ./ariac_entrypoint.sh /

--- a/ariac-server/ariac-server/Dockerfile
+++ b/ariac-server/ariac-server/Dockerfile
@@ -103,7 +103,7 @@ USER $USERNAME
 WORKDIR /home/$USERNAME
 
 # Get gazebo models early since it is big
-RUN wget -P /tmp/ https://bitbucket.org/osrf/gazebo_models/get/default.tar.gz \
+RUN wget -P /tmp/ https://github.com/osrf/gazebo_models/archive/master.zip \
  && mkdir -p $HOME/.gazebo/models \
  && tar -xvf /tmp/default.tar.gz -C $HOME/.gazebo/models --strip 1 \
  && rm /tmp/default.tar.gz

--- a/ariac-server/build-images.sh
+++ b/ariac-server/build-images.sh
@@ -16,7 +16,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo "${YELLOW}Build image: ariac-server${NOCOLOR}"
 
 UBUNTU_DISTRO=${1:-bionic}
-ROSDISTRO=${2:-melodic}
+ROSDISTRO=melodic
 case $UBUNTU_DISTRO in
   "bionic")
     ROSDISTRO="melodic"
@@ -31,10 +31,12 @@ case $UBUNTU_DISTRO in
     ;;
 esac
 
+BASE_DIMG=${2:-ros:${ROSDISTRO}-ros-base}
+
 DOCKER_ARGS="--no-cache"
 USERID=`id -u $USER`
 if [[ ${USERID} != 0 ]]; then
   DOCKER_ARGS="--build-arg USERID=${USERID}"
 fi
 
-docker build --force-rm ${DOCKER_ARGS} --build-arg UBUNTU_DISTRO=$UBUNTU_DISTRO --build-arg ROSDISTRO=$ROSDISTRO --tag ariac-server-$ROSDISTRO:latest $DIR/ariac-server
+docker build --force-rm ${DOCKER_ARGS} --build-arg BASE_DIMG="${BASE_DIMG}" --build-arg UBUNTU_DISTRO=$UBUNTU_DISTRO --build-arg ROSDISTRO=$ROSDISTRO --tag usnistgov/ariac:server-$UBUNTU_DISTRO $DIR/ariac-server

--- a/ariac-server/build-images.sh
+++ b/ariac-server/build-images.sh
@@ -15,6 +15,21 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo "${YELLOW}Build image: ariac-server${NOCOLOR}"
 
+UBUNTU_DISTRO=${1:-bionic}
+ROSDISTRO=${2:-melodic}
+case $UBUNTU_DISTRO in
+  "bionic")
+    ROSDISTRO="melodic"
+    ;;
+
+  "focal")
+    ROSDISTRO="noetic"
+    ;;
+
+  *)
+    ROSDISTRO="melodic"
+    ;;
+esac
 
 DOCKER_ARGS="--no-cache"
 USERID=`id -u $USER`
@@ -22,4 +37,4 @@ if [[ ${USERID} != 0 ]]; then
   DOCKER_ARGS="--build-arg USERID=${USERID}"
 fi
 
-docker build --force-rm ${DOCKER_ARGS} --tag ariac-server-melodic:latest $DIR/ariac-server
+docker build --force-rm ${DOCKER_ARGS} --build-arg UBUNTU_DISTRO=$UBUNTU_DISTRO --build-arg ROSDISTRO=$ROSDISTRO --tag ariac-server-$ROSDISTRO:latest $DIR/ariac-server


### PR DESCRIPTION
# Problem this PR aims to address
build img script hardcodes Ubuntu and ROS distros so a Docker image of other distros cannot be built without manually changing the code.

Related to https://github.com/130s/hut_utakata/issues/31

# Approach
build img script accepts Ubuntu distro, and ROS distro as well as an option.

# Known shortcoming
- Only Ubuntu 18.04/20.04, ROS melodic/noetic are supported ATM.
